### PR TITLE
Add CSS variables for global styles 

### DIFF
--- a/frontend/src/components/Style/GlobalStyle.tsx
+++ b/frontend/src/components/Style/GlobalStyle.tsx
@@ -14,6 +14,10 @@ export const GlobalStyle = createGlobalStyle`
     radial-gradient(at 0% 100%, hsla(207, 74%, 79%, 1) 0px, transparent 50%);
     --inbtwn-elem-padding: 16px;
     --main-border-radius: 8px;
+    --font-size-sm: 16px;
+    --font-size-md: 18px;
+    --font-size-lg: 20px;
+    --font-size-xlg: 22px;
 ;
   }
 

--- a/frontend/src/components/Style/GlobalStyle.tsx
+++ b/frontend/src/components/Style/GlobalStyle.tsx
@@ -18,6 +18,8 @@ export const GlobalStyle = createGlobalStyle`
     --font-size-md: 18px;
     --font-size-lg: 20px;
     --font-size-xl: 22px;
+    --device-width-tablet: 780px;
+    --device-width-laptop: 1020px;
 ;
   }
 

--- a/frontend/src/components/Style/GlobalStyle.tsx
+++ b/frontend/src/components/Style/GlobalStyle.tsx
@@ -26,4 +26,8 @@ export const GlobalStyle = createGlobalStyle`
     margin: 0;
     padding: 0;
   }
+
+  body {
+    font-size: var(--font-size-sm);
+  }
 `;

--- a/frontend/src/components/Style/GlobalStyle.tsx
+++ b/frontend/src/components/Style/GlobalStyle.tsx
@@ -17,7 +17,7 @@ export const GlobalStyle = createGlobalStyle`
     --font-size-sm: 16px;
     --font-size-md: 18px;
     --font-size-lg: 20px;
-    --font-size-xlg: 22px;
+    --font-size-xl: 22px;
 ;
   }
 


### PR DESCRIPTION
## Proposed Changes

#### Code changes
- Add CSS variables to the root element in `GlobalStyle.tsx`
  - Font size
    - `--font-size-sm: 16px`
    - `--font-size-md: 18px`
    - `--font-size-lg: 20px`
    - `--font-size-xl: 22px`
  - Media query
    - `--device-width-tablet: 780px`
    - `--device-width-laptop: 1020px`

#### Issues affected
- Resolves #14 

## Additional Info
- The media query for mobile is not needed because styling starts with mobile first in this project

## Screenshots/video
- None

## Testing Plan

- Check if all the variables work as expected on the google dev tool

## Checklist

#### Basics
- [x] Local QA is complete
- [x] No debugging `console.log()` statements
- [x] Unnessary commented-out code removed
- [x] Unused code removed (imports, functions, styles, etc - if it's not used anywhere, it's not in this PR)