### PR TITLE
Create the data-display component

### DIFF
--- a/frontend/src/components/Pages/Home/DataDisplay.tsx
+++ b/frontend/src/components/Pages/Home/DataDisplay.tsx
@@ -33,8 +33,18 @@ export default function DataDisplay() {
     <BlurContainer>
       <Container>
         <ToggleContainer>
-          <Toggle isSelected={selected === "latest"}>Latest</Toggle>
-          <Toggle isSelected={selected === "history"}>History</Toggle>
+          <Toggle
+            isSelected={selected === "latest"}
+            onClick={() => setSelected("latest")}
+          >
+            Latest
+          </Toggle>
+          <Toggle
+            isSelected={selected === "history"}
+            onClick={() => setSelected("history")}
+          >
+            History
+          </Toggle>
         </ToggleContainer>
         {selected === "latest" ? (
           <WeightData data={LATEST_DATA} />

--- a/frontend/src/components/Pages/Home/DataDisplay.tsx
+++ b/frontend/src/components/Pages/Home/DataDisplay.tsx
@@ -1,0 +1,47 @@
+import { useState } from "react";
+
+import styled from "styled-components";
+
+import WeightData from "./WeightData";
+import Toggle from "./common/Toggle";
+import HistoryData from "./HistoryData/HistoryData";
+import { BlurContainer } from "../../Style/BlurContainer.styled";
+
+// These are mock weight data and to be replaced with the actual data later
+const LATEST_DATA = { weight: "62.5", date: "2023-11-23" };
+const DATA_LIST = [
+  { weight: "62.5", date: "2023-11-23" },
+  { weight: "62.5", date: "2023-11-23" },
+  { weight: "62.5", date: "2023-11-23" },
+];
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 25px 50px;
+`;
+const ToggleContainer = styled.div`
+  display: flex;
+  justify-content: center;
+`;
+
+export default function DataDisplay() {
+  const [selected, setSelected] = useState("latest");
+
+  return (
+    <BlurContainer>
+      <Container>
+        <ToggleContainer>
+          <Toggle isSelected={selected === "latest"}>Latest</Toggle>
+          <Toggle isSelected={selected === "history"}>History</Toggle>
+        </ToggleContainer>
+        {selected === "latest" ? (
+          <WeightData data={LATEST_DATA} />
+        ) : (
+          <HistoryData dataList={DATA_LIST} />
+        )}
+      </Container>
+    </BlurContainer>
+  );
+}

--- a/frontend/src/components/Pages/Home/common/Toggle.tsx
+++ b/frontend/src/components/Pages/Home/common/Toggle.tsx
@@ -4,7 +4,11 @@ import styled from "styled-components";
 
 import { DEVICE_WIDTH, FONT_SIZE } from "../../../../utils/constants";
 
-type ToggleProps = { children?: ReactNode; isSelected: boolean };
+type ToggleProps = {
+  children: ReactNode;
+  isSelected: boolean;
+  onClick: () => void;
+};
 
 const StyledToggle = styled.div<ToggleProps>`
   padding: 10px 20px;
@@ -29,6 +33,10 @@ const StyledToggle = styled.div<ToggleProps>`
   }
 `;
 
-export default function Toggle({ children, isSelected }: ToggleProps) {
-  return <StyledToggle isSelected={isSelected}>{children}</StyledToggle>;
+export default function Toggle({ children, isSelected, onClick }: ToggleProps) {
+  return (
+    <StyledToggle isSelected={isSelected} onClick={onClick}>
+      {children}
+    </StyledToggle>
+  );
 }

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -12,3 +12,4 @@ export { default as Header } from "./Pages/Home/Header";
 export { default as WeightData } from "./Pages/Home/WeightData";
 export { default as HistoryData } from "./Pages/Home/HistoryData/HistoryData";
 export { default as Toggle } from "./Pages/Home/common/Toggle";
+export { default as DataDisplay } from "./Pages/Home/DataDisplay";


### PR DESCRIPTION
## Proposed Changes

#### Code changes
- Created `<DataDisplay />` in `frontend/src/components/Pages/Home`
- Added `<DataDisplay />` to the entry point
- Modify the props type of `<Toggle />` by adding a type for an onClick handler

#### Issues affected
- Resolves #48 

## Additional Info
- There is an error related to `isSelected`, One of the props of `<Toggle />`. But it is working as expected so I'll ignore this error for now and resolve it in another PR.

## Screenshots/video
⚠️The information displayed on the screen comes from mock data which is going to be replaced with actual data later
![data-display](https://github.com/HidemichiShimura/weight-tracker/assets/110521018/0744b098-83e2-4a17-8667-7d55d51ad5e2)

## Testing Plan
- Check if the toggle switches the displayed data as expected

## Checklist

#### Basics
- [x] Local QA is complete
- [x] No debugging `console.log()` statements
- [x] Unnessary commented-out code removed
- [x] Unused code removed (imports, functions, styles, etc - if it's not used anywhere, it's not in this PR)