### PR TITLE
Implement validation schema to the forms in <Menu />

### DIFF
--- a/frontend/src/components/Pages/Home/Menu/AddForm/AddForm.tsx
+++ b/frontend/src/components/Pages/Home/Menu/AddForm/AddForm.tsx
@@ -1,3 +1,5 @@
+import { useForm } from "react-hook-form";
+
 import {
   ErrText,
   Form,
@@ -7,19 +9,38 @@ import {
   Button,
 } from "../common/Form.styled";
 import { WEIGHT_INPUT_ATTRS, DATE_INPUT_ATTRS } from "../common/attribute";
+import {
+  AddValidationSchema,
+  AddValidationSchemaType,
+} from "@utils/CUDValidationSchema";
+import { zodResolver } from "@hookform/resolvers/zod";
 
 export default function AddForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<AddValidationSchemaType>({
+    mode: "onChange",
+    resolver: zodResolver(AddValidationSchema),
+  });
+
+  const onSubmit = (data: AddValidationSchemaType) => {
+    /* Here will be the logic of the create operation */
+    console.log(data);
+  };
+
   return (
-    <Form>
+    <Form onSubmit={handleSubmit(onSubmit)}>
       <InputContainer>
         <Label>Weight</Label>
-        <Input {...WEIGHT_INPUT_ATTRS} />
-        <ErrText></ErrText>
+        <Input {...WEIGHT_INPUT_ATTRS} {...register("weight")} />
+        <ErrText>{errors.weight?.message}</ErrText>
       </InputContainer>
       <InputContainer>
         <Label>Date</Label>
-        <Input {...DATE_INPUT_ATTRS} />
-        <ErrText></ErrText>
+        <Input {...DATE_INPUT_ATTRS} {...register("date")} />
+        <ErrText>{errors.date?.message}</ErrText>
       </InputContainer>
       <Button type="submit">Add</Button>
     </Form>

--- a/frontend/src/components/Pages/Home/Menu/DelForm/DelForm.tsx
+++ b/frontend/src/components/Pages/Home/Menu/DelForm/DelForm.tsx
@@ -1,3 +1,5 @@
+import { useForm } from "react-hook-form";
+
 import {
   ErrText,
   Form,
@@ -7,14 +9,33 @@ import {
   Button,
 } from "../common/Form.styled";
 import { DATE_INPUT_ATTRS } from "../common/attribute";
+import {
+  DelValidationSchema,
+  DelValidationSchemaType,
+} from "@utils/CUDValidationSchema";
+import { zodResolver } from "@hookform/resolvers/zod";
 
 export default function DelForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<DelValidationSchemaType>({
+    mode: "onChange",
+    resolver: zodResolver(DelValidationSchema),
+  });
+
+  const onSubmit = (data: DelValidationSchemaType) => {
+    /* Here will be the logic of the delete operation */
+    console.log(data);
+  };
+
   return (
-    <Form>
+    <Form onSubmit={handleSubmit(onSubmit)}>
       <InputContainer>
         <Label>Date</Label>
-        <Input {...DATE_INPUT_ATTRS} />
-        <ErrText></ErrText>
+        <Input {...DATE_INPUT_ATTRS} {...register("date")} />
+        <ErrText>{errors.date?.message}</ErrText>
       </InputContainer>
       <Button type="submit">Delete</Button>
     </Form>

--- a/frontend/src/components/Pages/Home/Menu/ModForm/ModForm.tsx
+++ b/frontend/src/components/Pages/Home/Menu/ModForm/ModForm.tsx
@@ -1,3 +1,5 @@
+import { useForm } from "react-hook-form";
+
 import {
   ErrText,
   Form,
@@ -7,19 +9,38 @@ import {
   Button,
 } from "../common/Form.styled";
 import { WEIGHT_INPUT_ATTRS, DATE_INPUT_ATTRS } from "../common/attribute";
+import {
+  ModValidationSchema,
+  ModValidationSchemaType,
+} from "@utils/CUDValidationSchema";
+import { zodResolver } from "@hookform/resolvers/zod";
 
 export default function ModForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<ModValidationSchemaType>({
+    mode: "onChange",
+    resolver: zodResolver(ModValidationSchema),
+  });
+
+  const onSubmit = (data: ModValidationSchemaType) => {
+    /* Here will be the logic of the update operation */
+    console.log(data);
+  };
+
   return (
-    <Form>
+    <Form onSubmit={handleSubmit(onSubmit)}>
       <InputContainer>
         <Label>Weight</Label>
-        <Input {...WEIGHT_INPUT_ATTRS} />
-        <ErrText></ErrText>
+        <Input {...WEIGHT_INPUT_ATTRS} {...register("weight")} />
+        <ErrText>{errors.weight?.message}</ErrText>
       </InputContainer>
       <InputContainer>
         <Label>Date</Label>
-        <Input {...DATE_INPUT_ATTRS} />
-        <ErrText></ErrText>
+        <Input {...DATE_INPUT_ATTRS} {...register("date")} />
+        <ErrText>{errors.date?.message}</ErrText>
       </InputContainer>
       <Button type="submit">Modify</Button>
     </Form>


### PR DESCRIPTION
## Proposed Changes

#### Code changes
- Implemented corresponding validation schemas to the forms in the menu

#### Issues affected
- Resolves #63

## Additional Info
- The schema for the date input may be changed later for convenience of data manipulation

## Screenshots/video
### Add
- Weight
  - Empty Input
![image](https://github.com/HidemichiShimura/weight-tracker/assets/110521018/3ae1eac5-509d-4da4-8603-fc7cdb92a599)

  - Invalid Input Type
![image](https://github.com/HidemichiShimura/weight-tracker/assets/110521018/3553dd04-a282-455b-bf63-0ccea9d5b3e7)

- Date
  - Invalid date(a date after today)
![image](https://github.com/HidemichiShimura/weight-tracker/assets/110521018/3c40260e-5b31-4cb1-80d9-d4a092e2af47)

## Testing Plan
- Check if the validation works and displays the matching error messages

## Checklist

#### Basics
- [x] Local QA is complete
- [x] No debugging `console.log()` statements
- [x] Unnessary commented-out code removed
- [x] Unused code removed (imports, functions, styles, etc - if it's not used anywhere, it's not in this PR)