### PR TITLE
Display latest data on the home page

### DIFF
--- a/frontend/src/components/Pages/Home/DataDisplay/DataDisplay.styled.ts
+++ b/frontend/src/components/Pages/Home/DataDisplay/DataDisplay.styled.ts
@@ -1,0 +1,12 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 25px 50px;
+`;
+export const ToggleContainer = styled.div`
+  display: flex;
+  justify-content: center;
+`;

--- a/frontend/src/components/Pages/Home/DataDisplay/DataDisplay.tsx
+++ b/frontend/src/components/Pages/Home/DataDisplay/DataDisplay.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState } from "react";
 
-import styled from "styled-components";
-
 import { BlurContainer, Toggle, WeightData, HistoryData } from "@components";
+import { Container, ToggleContainer } from "./DataDisplay.styled";
 import { getData } from "@utils/functions";
 
 // These are mock weight data and to be replaced with the actual data later
@@ -11,17 +10,6 @@ const DATA_LIST = [
   { weight: "62.5", date: "2023-11-23" },
   { weight: "62.5", date: "2023-11-23" },
 ];
-
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-  padding: 25px 50px;
-`;
-const ToggleContainer = styled.div`
-  display: flex;
-  justify-content: center;
-`;
 
 function getLatestData(dataList: Array<{ weight: number; date: Date }>) {
   let latestData = dataList[0] || {};

--- a/frontend/src/components/Pages/Home/DataDisplay/DataDisplay.tsx
+++ b/frontend/src/components/Pages/Home/DataDisplay/DataDisplay.tsx
@@ -1,11 +1,11 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import styled from "styled-components";
 
 import { BlurContainer, Toggle, WeightData, HistoryData } from "@components";
+import { getData } from "@utils/functions";
 
 // These are mock weight data and to be replaced with the actual data later
-const LATEST_DATA = { weight: "62.5", date: "2023-11-23" };
 const DATA_LIST = [
   { weight: "62.5", date: "2023-11-23" },
   { weight: "62.5", date: "2023-11-23" },
@@ -23,8 +23,31 @@ const ToggleContainer = styled.div`
   justify-content: center;
 `;
 
+function getLatestData(dataList: Array<{ weight: number; date: Date }>) {
+  let latestData = dataList[0] || {};
+
+  dataList.forEach((data) => {
+    const date = new Date(data.date);
+
+    if (new Date(latestData.date).valueOf() < date.valueOf()) latestData = data;
+  });
+
+  return latestData;
+}
+
 export default function DataDisplay() {
   const [selected, setSelected] = useState("latest");
+  const [latestData, setLatestData] = useState<any>({});
+
+  useEffect(() => {
+    const res = getData();
+
+    res.then((dataList: any) => {
+      const latestD = getLatestData(dataList);
+
+      setLatestData(latestD);
+    });
+  }, []);
 
   return (
     <BlurContainer>
@@ -44,7 +67,7 @@ export default function DataDisplay() {
           </Toggle>
         </ToggleContainer>
         {selected === "latest" ? (
-          <WeightData data={LATEST_DATA} />
+          <WeightData data={latestData} />
         ) : (
           <HistoryData dataList={DATA_LIST} />
         )}

--- a/frontend/src/utils/functions/getData.ts
+++ b/frontend/src/utils/functions/getData.ts
@@ -5,8 +5,9 @@ export default async function getData() {
   try {
     const resData = await axios.get("http://localhost:80");
 
-    return resData.status === 200;
+    return resData.data;
   } catch (err) {
     console.log(err);
+    return;
   }
 }


### PR DESCRIPTION
## Proposed Changes

#### Code changes
- Implemented fetching data from DB
- Replaced the mock data `LATEST_DATA`with a state `latestData`
- Extracted styles of `<DataDisplay />` to another style file

#### Issues affected
- Resolves #98 

## Additional Info
- Type `any` is going to be replaced with the matching type later

## Screenshots/video
![image](https://github.com/HidemichiShimura/weight-tracker/assets/110521018/36d5ed4b-8368-4cee-b00f-8a31f5feded9)

## Testing Plan
- Check if the latest data is displayed when the page is loaded
- Check if the latest data is displayed when the page is loaded after the crud operations are executed

## Checklist

#### Basics
- [x] Local QA is complete
- [x] No debugging `console.log()` statements
- [x] Unnessary commented-out code removed
- [x] Unused code removed (imports, functions, styles, etc - if it's not used anywhere, it's not in this PR)