### PR TITLE
Displaying the history data on the home page

### DIFF
--- a/frontend/src/components/Pages/Home/DataDisplay/DataDisplay.tsx
+++ b/frontend/src/components/Pages/Home/DataDisplay/DataDisplay.tsx
@@ -4,13 +4,6 @@ import { BlurContainer, Toggle, WeightData, HistoryData } from "@components";
 import { Container, ToggleContainer } from "./DataDisplay.styled";
 import { getData } from "@utils/functions";
 
-// These are mock weight data and to be replaced with the actual data later
-const DATA_LIST = [
-  { weight: "62.5", date: "2023-11-23" },
-  { weight: "62.5", date: "2023-11-23" },
-  { weight: "62.5", date: "2023-11-23" },
-];
-
 function getLatestData(dataList: Array<{ weight: number; date: Date }>) {
   let latestData = dataList[0] || {};
 
@@ -26,14 +19,17 @@ function getLatestData(dataList: Array<{ weight: number; date: Date }>) {
 export default function DataDisplay() {
   const [selected, setSelected] = useState("latest");
   const [latestData, setLatestData] = useState<any>({});
+  const [allData, setAllData] = useState<any>([{}]);
 
   useEffect(() => {
     const res = getData();
 
     res.then((dataList: any) => {
       const latestD = getLatestData(dataList);
+      const allD = dataList;
 
       setLatestData(latestD);
+      setAllData(allD);
     });
   }, []);
 
@@ -57,7 +53,7 @@ export default function DataDisplay() {
         {selected === "latest" ? (
           <WeightData data={latestData} />
         ) : (
-          <HistoryData dataList={DATA_LIST} />
+          <HistoryData dataList={allData} />
         )}
       </Container>
     </BlurContainer>


### PR DESCRIPTION
## Proposed Changes

#### Code changes
- Created a state for the history data fetched from DB
- Replaced the mock data `DATA_LIST` with the state as props to `<HistoryData />`

#### Issues affected
- Resolves #100

## Additional Info
- None

## Screenshots/video
![image](https://github.com/HidemichiShimura/weight-tracker/assets/110521018/37c855c5-b4aa-44d1-abd6-ba28b207b8c0)

## Testing Plan
- Check if all the data in DB is displayed in the history section when the page is loaded.
- Check if the displayed history data changes when the page is loaded after crud operations

## Checklist

#### Basics
- [x] Local QA is complete
- [x] No debugging `console.log()` statements
- [x] Unnessary commented-out code removed
- [x] Unused code removed (imports, functions, styles, etc - if it's not used anywhere, it's not in this PR)