### PR TITLE
Implement temporary navigation to the home page from the login/signup portals

### DIFF
--- a/frontend/src/components/Pages/Login/LoginPortal.tsx
+++ b/frontend/src/components/Pages/Login/LoginPortal.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from "react";
+import { useNavigate } from "react-router-dom"; // Used for temporary navigation to the home page
 
 import { useForm } from "react-hook-form";
 
@@ -28,11 +29,11 @@ export default function LoginPortal() {
     mode: "onChange",
     resolver: zodResolver(EntryValidationSchema),
   });
-
   const onSubmit = (data: EntryValidationSchemaType) => {
     /* Here will be the logic of login authentication */
     console.log(data);
   };
+  const navigate = useNavigate(); // Used for temporary navigation to the home page
 
   return (
     <BlurContainer>
@@ -56,7 +57,10 @@ export default function LoginPortal() {
             </InputContainer>
           );
         })}
-        <Button type="submit">Login</Button>
+        {/* Temporary navigation to the home page */}
+        <Button type="submit" onClick={() => navigate("/Home")}>
+          Login
+        </Button>
       </Form>
     </BlurContainer>
   );

--- a/frontend/src/components/Pages/SignUp/SignUpPortal.tsx
+++ b/frontend/src/components/Pages/SignUp/SignUpPortal.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from "react";
+import { useNavigate } from "react-router-dom"; // Used for temporary navigation to the home page
 
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -28,11 +29,11 @@ export default function SignUpPortal() {
     mode: "onChange",
     resolver: zodResolver(EntryValidationSchema),
   });
-
   const onSubmit = (data: EntryValidationSchemaType) => {
     /* Here will be the logic of login authentication */
     console.log(data);
   };
+  const navigate = useNavigate(); // Used for temporary navigation to the home page
 
   return (
     <BlurContainer>
@@ -56,7 +57,10 @@ export default function SignUpPortal() {
             </InputContainer>
           );
         })}
-        <Button type="submit">SignUp</Button>
+        {/* Temporary navigation to the home page */}
+        <Button type="submit" onClick={() => navigate("/Home")}>
+          SignUp
+        </Button>
       </Form>
     </BlurContainer>
   );


### PR DESCRIPTION
## Proposed Changes

#### Code changes
- Implemented navigation to the home page in `<LoginPortal />` and `<SignupPortal />`

#### Issues affected
- Resolves #107 

## Additional Info
- This is a temporary navigation until login/signup auth is implemented

## Screenshots/video
- Login to Home
![nav-login](https://github.com/HidemichiShimura/weight-tracker/assets/110521018/9a34ea36-4695-4b57-956d-90cffb14c1e1)

- Signup to Home
![nav-signup](https://github.com/HidemichiShimura/weight-tracker/assets/110521018/a6ae4777-c582-483f-af30-b3cf3dba050a)

## Testing Plan
- Check if the navigation from the login/signup pages work when the buttons are pressed

## Checklist

#### Basics
- [x] Local QA is complete
- [x] No debugging `console.log()` statements
- [x] Unnessary commented-out code removed
- [x] Unused code removed (imports, functions, styles, etc - if it's not used anywhere, it's not in this PR)