### PR TITLE
Implement temporary navigation to the home page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,7 @@ import {
   BrowserRouter as Router,
   Routes,
   Route,
-  Navigate,
+  // Navigate, This is not used in the temporary routes
 } from "react-router-dom";
 
 import { GlobalStyle } from "@components";
@@ -14,8 +14,15 @@ function App() {
       <GlobalStyle />
       <Router>
         <Routes>
+          {/* These are supposed to be the final routes
           <Route index element={<Login />} />
           <Route path="/Login" element={<Navigate to="/" />} />
+          <Route path="/SignUp" element={<SignUp />} />
+          <Route path="/Home" element={<Home />} /> 
+          */}
+          {/* These are temporary routes until the user auth feature is implemented */}
+          <Route index element={<Home />} />
+          <Route path="/Login" element={<Login />} />
           <Route path="/SignUp" element={<SignUp />} />
           <Route path="/Home" element={<Home />} />
         </Routes>


### PR DESCRIPTION
## Proposed Changes

#### Code changes
- Set the index route to `<Home />`
- Deactivated the redirection from `/Login` to `/`

#### Issues affected
- Resolves #111  

## Additional Info
- #107 didn't implement the temporary navigation from the login/signup page to the home page, so I'll implement another temporary navigation to the home page at the path `/`. This change is going to be reverted when the user auth feature is added.

## Screenshots/video
![temp-nav](https://github.com/HidemichiShimura/weight-tracker/assets/110521018/f045c5b4-c736-4405-a070-2d762888f524)

## Testing Plan
- Test the navigation to the home page at the path `/`
- Test the other paths to check if the each path navigates to the matching page

## Checklist

#### Basics
- [x] Local QA is complete
- [x] No debugging `console.log()` statements
- [x] Unnessary commented-out code removed
- [x] Unused code removed (imports, functions, styles, etc - if it's not used anywhere, it's not in this PR)